### PR TITLE
[wip] Arrange about CChainParams.

### DIFF
--- a/bitcoin-msvc.sln
+++ b/bitcoin-msvc.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.4
+VisualStudioVersion = 15.0.26403.7
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "_bitcoin_common", "_bitcoin_common.vcxproj", "{8EFFD767-7623-4556-9A30-36533462915E}"
 EndProject
@@ -14,8 +14,6 @@ EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "db_static", "db-4.8.30\build_windows\db_static.vcxproj", "{671539AA-D9A6-4B7B-8044-61B511D6F432}"
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "sample", "sample\sample.vcxproj", "{6AD42D39-92E6-4116-89D2-EE2BAA8ABB03}"
-EndProject
-Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "test_bitcoin", "test_bitcoin\test_bitcoin.vcxproj", "{D943771F-36F4-453F-8A57-3FB8340F9FAD}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -73,14 +71,6 @@ Global
 		{6AD42D39-92E6-4116-89D2-EE2BAA8ABB03}.Release|x64.Build.0 = Release|x64
 		{6AD42D39-92E6-4116-89D2-EE2BAA8ABB03}.Release|x86.ActiveCfg = Release|Win32
 		{6AD42D39-92E6-4116-89D2-EE2BAA8ABB03}.Release|x86.Build.0 = Release|Win32
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Debug|x64.ActiveCfg = Debug|x64
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Debug|x64.Build.0 = Debug|x64
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Debug|x86.ActiveCfg = Debug|Win32
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Debug|x86.Build.0 = Debug|Win32
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Release|x64.ActiveCfg = Release|x64
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Release|x64.Build.0 = Release|x64
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Release|x86.ActiveCfg = Release|Win32
-		{D943771F-36F4-453F-8A57-3FB8340F9FAD}.Release|x86.Build.0 = Release|Win32
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/sample/sample.cpp
+++ b/sample/sample.cpp
@@ -3,6 +3,7 @@
 #include "base58.h"
 #include "BitcoinAddress.h"
 #include <secp256k1.h>
+#include "chainparams.h"
 
 static const char* g_pszBase58 = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 
@@ -116,32 +117,48 @@ static void decodePrint(const std::string& s) {
     }
     printf("}\n");
 }
+
+int main_impl();
+
 int main()
 {
-    // std::vector<unsigned char> v(1, 239); // 要素数 1、中身は [239] なリストができる.
-    // unsigned char* p = &v[0];
-
-    unsigned char data[] = { 0,0,0,0,0x11,2,0xE }; // → "11116iLu" になる.
-    // unsigned char data[] = "abc";
-    // unsigned char data[] = { 0xFF };
-    std::string s = MyEncodeBase58(data, data + sizeof(data));
-    printf("%s\n", s.c_str());
-
-    //decodePrint(s);
-    //decodePrint("11116iLu");
-    //decodePrint("1111 6iLu");
-    decodePrint("11116iLu");
-
-    
-
-    // printf("0x%X\n", SECP256K1_EC_COMPRESSED);
-    // printf("0x%X\n", SECP256K1_EC_UNCOMPRESSED);
-    return 0;
-
     ECC_Start();
 
+    try {
+        main_impl();
+    }
+    catch (const std::exception& ex) {
+        printf("Error: %s\n", ex.what());
+    }
+
+    ECC_Stop();
+}
+
+int main_impl()
+{
+    // BASE58関連実験
+    if (0) {
+        // std::vector<unsigned char> v(1, 239); // 要素数 1、中身は [239] なリストができる.
+        // unsigned char* p = &v[0];
+
+        unsigned char data[] = { 0,0,0,0,0x11,2,0xE }; // → "11116iLu" になる.
+                                                       // unsigned char data[] = "abc";
+                                                       // unsigned char data[] = { 0xFF };
+        std::string s = MyEncodeBase58(data, data + sizeof(data));
+        printf("%s\n", s.c_str());
+
+        //decodePrint(s);
+        //decodePrint("11116iLu");
+        //decodePrint("1111 6iLu");
+        decodePrint("11116iLu");
+
+        // printf("0x%X\n", SECP256K1_EC_COMPRESSED);
+        // printf("0x%X\n", SECP256K1_EC_UNCOMPRESSED);
+    }
+
+
     // secret_key prefix の確認.
-    {
+    if(1) {
         CKey key;
 
         // 9 で始まる 51 文字.
@@ -153,6 +170,11 @@ int main()
         SelectParams(NETWORK_REGTEST);
         key.MakeNewKey(true);
         printf("PRIVKEY in REGTEST: %s (%d)\n", key.GetBase58stringWithNetworkSecretKeyPrefix().c_str(), strlen(key.GetBase58stringWithNetworkSecretKeyPrefix().c_str()));
+
+        // L で始まる 52 文字.
+        SelectParams(NETWORK_MAIN);
+        key.MakeNewKey(true);
+        printf("PRIVKEY in MAINNET: %s (%d)\n", key.GetBase58stringWithNetworkSecretKeyPrefix().c_str(), strlen(key.GetBase58stringWithNetworkSecretKeyPrefix().c_str()));
     }
     
 
@@ -190,6 +212,6 @@ int main()
 
 
 
-    ECC_Stop();
+    
     return 0;
 }

--- a/src/ChainParamsUtil.cpp
+++ b/src/ChainParamsUtil.cpp
@@ -10,8 +10,6 @@
 #include "util.h"
 #include "utilstrencodings.h"
 
-std::map<NetworkType, CChainParams*> CChainParamsUtil::m_paramsOfType;
-
 CBlock CChainParamsUtil::_CreateGenesisBlockImpl(
     const char* pszTimestamp,
     const CScript& genesisOutputScript,

--- a/src/ChainParamsUtil.h
+++ b/src/ChainParamsUtil.h
@@ -31,12 +31,21 @@ public:
         int32_t nVersion,
         const CAmount& genesisReward
     );
-    static CChainParams* GetParamsOfNetworkType(NetworkType networkType) {
+};
+
+class CChainParamsPool{
+public:
+    static CChainParamsPool* Instance() {
+        static CChainParamsPool theInstance;
+        return &theInstance;
+    }
+public:
+    CChainParams* GetParamsOfNetworkType(NetworkType networkType) {
         return m_paramsOfType[networkType];
     }
-    static void RegisterParamsOfNetworkType(NetworkType networkType, CChainParams* pParams) {
+    void RegisterParamsOfNetworkType(NetworkType networkType, CChainParams* pParams) {
         m_paramsOfType[networkType] = pParams;
     }
 private:
-    static std::map<NetworkType, CChainParams*> m_paramsOfType;
+    std::map<NetworkType, CChainParams*> m_paramsOfType;
 };

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -1,4 +1,4 @@
-// Copyright (c) 2010 Satoshi Nakamoto
+﻿// Copyright (c) 2010 Satoshi Nakamoto
 // Copyright (c) 2009-2016 The Bitcoin Core developers
 // Distributed under the MIT software license, see the accompanying
 // file COPYING or http://www.opensource.org/licenses/mit-license.php.
@@ -8,6 +8,22 @@
 #include "ChainParamsUtil.h"
 
 static CChainParams* g_pCurrentParams = 0;
+
+void CChainParams::Initialize()
+{
+    // 重複除外.
+    static int flag = 0;
+    if (flag)return;
+    flag = 1;
+
+    // インスタンス明示初期化.
+    void Init1();
+    void Init2();
+    void Init3();
+    Init1();
+    Init2();
+    Init3();
+}
 
 CChainParams::CChainParams(NetworkType networkType)
 {
@@ -31,6 +47,7 @@ CChainParams& Params(NetworkType chain)
 
 void SelectParams(NetworkType network)
 {
+    CChainParams::Initialize();
     SelectBaseParams(network);
     g_pCurrentParams = &Params(network);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -9,26 +9,10 @@
 
 static CChainParams* g_pCurrentParams = 0;
 
-void CChainParams::Initialize()
-{
-    // 重複除外.
-    static int flag = 0;
-    if (flag)return;
-    flag = 1;
-
-    // インスタンス明示初期化.
-    void Init1();
-    void Init2();
-    void Init3();
-    Init1();
-    Init2();
-    Init3();
-}
-
 CChainParams::CChainParams(NetworkType networkType)
 {
     m_networkType = networkType;
-    CChainParamsUtil::RegisterParamsOfNetworkType(m_networkType, this);
+    CChainParamsPool::Instance()->RegisterParamsOfNetworkType(m_networkType, this);
 }
 
 const CChainParams &Params() {
@@ -38,7 +22,7 @@ const CChainParams &Params() {
 
 CChainParams& Params(NetworkType chain)
 {
-    CChainParams* p = CChainParamsUtil::GetParamsOfNetworkType(chain);
+    CChainParams* p = CChainParamsPool::Instance()->GetParamsOfNetworkType(chain);
     if (!p) {
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
     }
@@ -47,7 +31,6 @@ CChainParams& Params(NetworkType chain)
 
 void SelectParams(NetworkType network)
 {
-    CChainParams::Initialize();
     SelectBaseParams(network);
     g_pCurrentParams = &Params(network);
 }

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -35,3 +35,18 @@ void SelectParams(NetworkType network)
     g_pCurrentParams = &Params(network);
 }
 
+// 明示的な参照により無理やりグローバル変数のインスタンス化を行わせる.
+// これをやらないと特定のグローバル変数が未使用とみなされて最適化か何かの理由で存在が抹消されるっぽい.
+// つまりコンストラクタが呼ばれない.
+// 本当はこういうの書きたくないんだけど….
+class CMainParams;
+extern CMainParams g_mainParams;
+auto p1 = &g_mainParams;
+
+class CTestNetParams;
+extern CTestNetParams g_testNetParams;
+auto p2 = &g_testNetParams;
+
+class CRegTestParams;
+extern CRegTestParams g_regTestParams;
+auto p3 = &g_regTestParams;

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -52,6 +52,9 @@ struct ChainTxData {
 class CChainParams
 {
 public:
+    static void Initialize();
+
+public:
     enum Base58Type {
         PUBKEY_ADDRESS, // 公開鍵アドレス.
         SCRIPT_ADDRESS, // スクリプトアドレス.
@@ -84,6 +87,8 @@ public:
     const std::vector<SeedSpec6>& FixedSeeds() const { return vFixedSeeds; }
     const CCheckpointData& Checkpoints() const { return checkpointData; }
     const ChainTxData& TxData() const { return chainTxData; }
+private:
+    CChainParams(); // 引数無しの初期化は認めない. (ダミー宣言. 実装は存在しない)
 protected:
     CChainParams(NetworkType networkType);
 
@@ -104,6 +109,7 @@ protected:
     CCheckpointData checkpointData;
     ChainTxData chainTxData;
 };
+
 
 /**
  * Return the currently selected parameters. This won't change after app

--- a/src/chainparams.h
+++ b/src/chainparams.h
@@ -52,9 +52,6 @@ struct ChainTxData {
 class CChainParams
 {
 public:
-    static void Initialize();
-
-public:
     enum Base58Type {
         PUBKEY_ADDRESS, // 公開鍵アドレス.
         SCRIPT_ADDRESS, // スクリプトアドレス.

--- a/src/chainparams_1_mainnet.cpp
+++ b/src/chainparams_1_mainnet.cpp
@@ -120,4 +120,9 @@ public:
         };
     }
 };
-static CMainParams mainParams;
+CMainParams* g_mainParams;
+
+void Init1() {
+    g_mainParams = new CMainParams();
+}
+

--- a/src/chainparams_1_mainnet.cpp
+++ b/src/chainparams_1_mainnet.cpp
@@ -120,6 +120,5 @@ public:
         };
     }
 };
-#pragma optimize("", off)
+
 CMainParams g_mainParams;
-#pragma optimize("", on)

--- a/src/chainparams_1_mainnet.cpp
+++ b/src/chainparams_1_mainnet.cpp
@@ -120,9 +120,6 @@ public:
         };
     }
 };
-CMainParams* g_mainParams;
-
-void Init1() {
-    g_mainParams = new CMainParams();
-}
-
+#pragma optimize("", off)
+CMainParams g_mainParams;
+#pragma optimize("", on)

--- a/src/chainparams_2_testnet.cpp
+++ b/src/chainparams_2_testnet.cpp
@@ -95,4 +95,9 @@ public:
         };
     }
 };
-static CTestNetParams testNetParams;
+CTestNetParams* g_testNetParams;
+
+void Init2() {
+    g_testNetParams = new CTestNetParams();
+}
+

--- a/src/chainparams_2_testnet.cpp
+++ b/src/chainparams_2_testnet.cpp
@@ -95,9 +95,4 @@ public:
         };
     }
 };
-CTestNetParams* g_testNetParams;
-
-void Init2() {
-    g_testNetParams = new CTestNetParams();
-}
-
+static CTestNetParams g_testNetParams;

--- a/src/chainparams_2_testnet.cpp
+++ b/src/chainparams_2_testnet.cpp
@@ -95,4 +95,4 @@ public:
         };
     }
 };
-static CTestNetParams g_testNetParams;
+CTestNetParams g_testNetParams;

--- a/src/chainparams_3_regtest.cpp
+++ b/src/chainparams_3_regtest.cpp
@@ -87,10 +87,14 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
 };
-static CRegTestParams regTestParams;
+CRegTestParams* g_regTestParams;
 
 
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
     static_cast<CRegTestParams&>(Params(NETWORK_REGTEST)).UpdateBIP9Parameters(d, nStartTime, nTimeout);
+}
+
+void Init3() {
+    g_regTestParams = new CRegTestParams();
 }

--- a/src/chainparams_3_regtest.cpp
+++ b/src/chainparams_3_regtest.cpp
@@ -87,14 +87,10 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
 };
-CRegTestParams* g_regTestParams;
+static CRegTestParams g_regTestParams;
 
 
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)
 {
     static_cast<CRegTestParams&>(Params(NETWORK_REGTEST)).UpdateBIP9Parameters(d, nStartTime, nTimeout);
-}
-
-void Init3() {
-    g_regTestParams = new CRegTestParams();
 }

--- a/src/chainparams_3_regtest.cpp
+++ b/src/chainparams_3_regtest.cpp
@@ -87,7 +87,7 @@ public:
         consensus.vDeployments[d].nTimeout = nTimeout;
     }
 };
-static CRegTestParams g_regTestParams;
+CRegTestParams g_regTestParams;
 
 
 void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime, int64_t nTimeout)

--- a/src/chainparamsbase.cpp
+++ b/src/chainparamsbase.cpp
@@ -56,7 +56,7 @@ public:
         nRPCPort = 8332;
     }
 };
-static CBaseMainParams mainParams;
+static CBaseMainParams g_baseMainParams;
 
 /**
  * Testnet (v3)
@@ -70,7 +70,7 @@ public:
         strDataDir = "testnet3";
     }
 };
-static CBaseTestNetParams testNetParams;
+static CBaseTestNetParams g_baseTestNetParams;
 
 /*
  * Regression test
@@ -84,7 +84,7 @@ public:
         strDataDir = "regtest";
     }
 };
-static CBaseRegTestParams regTestParams;
+static CBaseRegTestParams g_baseRegTestParams;
 
 static CBaseChainParams* pCurrentBaseParams = 0;
 
@@ -97,11 +97,11 @@ const CBaseChainParams& BaseParams()
 CBaseChainParams& BaseParams(NetworkType chain)
 {
     if (chain == NETWORK_MAIN)
-        return mainParams;
+        return g_baseMainParams;
     else if (chain == NETWORK_TESTNET)
-        return testNetParams;
+        return g_baseTestNetParams;
     else if (chain == NETWORK_REGTEST)
-        return regTestParams;
+        return g_baseRegTestParams;
     else
         throw std::runtime_error(strprintf("%s: Unknown chain %s.", __func__, chain));
 }

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -330,6 +330,8 @@ void ECC_Start() {
     }
 
     secp256k1_context_sign = ctx;
+
+    CChainParams::Initialize(); // 仮.
 }
 
 void ECC_Stop() {

--- a/src/key.cpp
+++ b/src/key.cpp
@@ -330,8 +330,6 @@ void ECC_Start() {
     }
 
     secp256k1_context_sign = ctx;
-
-    CChainParams::Initialize(); // 仮.
 }
 
 void ECC_Stop() {


### PR DESCRIPTION
master の wip 解消用。一旦 master-tmp へのマージが完了したら master-tmp の内容で master のほうに force push する。

対応内容：CMainParams, CTestNetParams, CRegTestParams のグローバル変数を定義しているが、それのコンストラクタが何故か呼ばれないことがあり、それの対症療法として変数への参照を適当に定義した（ものすごく気持ち悪い）

現在の状況：試行錯誤したコミットを wip として記録しているのであとでちゃんと squash する。tmp って付いてるコミットは不要（検証中のビルド時間を短くするためにテストコードビルドを省くコミットを入れた）なので rebase で消す予定。

一応現段階では問題は解決したが、気持ち悪い対症療法は嫌なのでもう少し調査を進めて根本的な解決を探りたい。理想をいえばそれが解決してから squash とマージを行う。調査の結果、どうにもならなかったら対症療法のまま進めてしまう。
